### PR TITLE
feat(query): Add `array_contains_any` operator and refactor query tests

### DIFF
--- a/ampf/base/base_async_query.py
+++ b/ampf/base/base_async_query.py
@@ -59,7 +59,9 @@ class BaseAsyncQuery[T: BaseModel | VersionedBaseModel](ABC):
                     case "in":
                         if attr in value:
                             yield o
-
+                    case "array_contains_any":
+                        if any(item in value for item in attr):
+                            yield o
         return BaseAsyncQuery(it)
 
     async def find_nearest(self, embedding: List[float], limit: Optional[int] = None) -> AsyncIterable[T]:

--- a/ampf/base/base_query.py
+++ b/ampf/base/base_query.py
@@ -7,7 +7,8 @@ from typing import Any, Callable, Iterator, List, Optional, Tuple
 from pydantic import BaseModel
 from typing_extensions import Literal
 
-OP = Literal["==", "!=", "<", "<=", ">", ">=", "in"]
+OP = Literal["==", "!=", "<", "<=", ">", ">=", "in", "array_contains_any"]
+
 
 class BaseQuery[T: BaseModel](ABC):
     """Base query with defalt, brute force implementation."""
@@ -43,6 +44,8 @@ class BaseQuery[T: BaseModel](ABC):
                     return (o for o in src() if o.__getattribute__(field) >= value)
                 case "in":
                     return (o for o in src() if o.__getattribute__(field) in value)
+                case "array_contains_any":
+                    return (o for o in src() if any(e in value for e in o.__getattribute__(field)))
                 case _:
                     raise ValueError(f"Unknown operator {op}")
 

--- a/tests/all_storage/test_all_async_query_storage.py
+++ b/tests/all_storage/test_all_async_query_storage.py
@@ -15,6 +15,7 @@ class D(BaseModel):
     name: str
     value: str
     embedding: Optional[List[float]] = None
+    tags: Optional[List[str]] = None
 
 
 class Duuid(BaseModel):
@@ -83,7 +84,20 @@ async def test_query_uuid(storage_uuid: BaseAsyncQueryStorage):
     # Given: A stred element with UUID filed
     d = Duuid(name="foo", value="beer")
     await storage_uuid.create(d)
-    # When: Filrter by UUID
+    # When: Filter by UUID
     ret = [item async for item in storage_uuid.where("uuid", "==", d.uuid).get_all()]
     # Then: The element is returned
     assert len(ret) == 1
+
+@pytest.mark.asyncio
+async def test_query_array_contains_any(storage: BaseAsyncQueryStorage):
+    await storage.save(D(name="d1", value="v1", tags=["tag1", "tag2"]))
+    await storage.save(D(name="d2", value="v2", tags=["tag2", "tag3"]))
+    await storage.save(D(name="d3", value="v3", tags=["tag4"]))
+
+    result = [item async for item in storage.where("tags", "array_contains_any", ["tag1", "tag4"]).get_all()]
+    assert len(result) == 2
+    assert {r.name for r in result} == {"d1", "d3"}
+
+    result = [item async for item in storage.where("tags", "array_contains_any", ["tag5"]).get_all()]
+    assert len(result) == 0

--- a/tests/all_storage/test_all_async_query_storage.py
+++ b/tests/all_storage/test_all_async_query_storage.py
@@ -1,0 +1,89 @@
+from typing import List, Optional, Type
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic import BaseModel, Field
+
+from ampf.base import BaseAsyncStorage
+from ampf.base.base_async_query_storage import BaseAsyncQueryStorage
+from ampf.gcp import GcpAsyncStorage
+from ampf.in_memory import InMemoryAsyncStorage
+from ampf.local import JsonMultiFilesAsyncStorage, JsonOneFileAsyncStorage
+
+
+class D(BaseModel):
+    name: str
+    value: str
+    embedding: Optional[List[float]] = None
+
+
+class Duuid(BaseModel):
+    uuid: UUID = Field(default_factory=uuid4)
+    name: str
+    value: str
+
+
+@pytest.fixture(
+    params=[
+        InMemoryAsyncStorage,
+        JsonOneFileAsyncStorage,
+        JsonMultiFilesAsyncStorage,
+        GcpAsyncStorage,
+    ]
+)
+async def storage(gcp_factory, request, tmp_path):
+    clazz: Type[BaseAsyncStorage[D]] = request.param
+    if clazz in [JsonOneFileAsyncStorage, JsonMultiFilesAsyncStorage]:
+        storage = clazz("tests-ampf-gcp", D, root_path=tmp_path)  # type: ignore
+    else:
+        storage = clazz("tests-ampf-gcp", D)
+    yield storage
+    await storage.drop()
+
+
+@pytest.fixture(
+    params=[
+        InMemoryAsyncStorage,
+        JsonOneFileAsyncStorage,
+        JsonMultiFilesAsyncStorage,
+        GcpAsyncStorage,
+    ]
+)
+async def storage_uuid(request, tmp_path):
+    clazz: Type[BaseAsyncStorage[Duuid]] = request.param
+    if clazz in [JsonOneFileAsyncStorage, JsonMultiFilesAsyncStorage]:
+        storage = clazz("tests-ampf-gcp", Duuid, root_path=tmp_path)  # type: ignore
+    else:
+        storage = clazz("tests-ampf-gcp", Duuid)
+    yield storage
+    await storage.drop()
+
+
+@pytest.mark.asyncio
+async def test_query(storage: BaseAsyncQueryStorage):
+    # Given: Stored two elements with the same value and one with other
+    await storage.save(D(name="foo", value="beer"))
+    await storage.save(D(name="bar", value="beer"))
+    await storage.save(D(name="baz", value="wine"))
+    # When: Get all items with "beer"
+    ret = [item async for item in storage.where("value", "==", "beer").get_all()]
+    # Then: Two items are returned
+    assert len(ret) == 2
+    assert ret[0].name in ["foo", "bar"]
+    assert ret[1].name in ["foo", "bar"]
+    # When: Get all items different than "beer"
+    ret = [item async for item in storage.where("value", "!=", "beer").get_all()]
+    # Then: One item is returned
+    assert len(ret) == 1
+    assert ret[0].name == "baz"
+
+
+@pytest.mark.asyncio
+async def test_query_uuid(storage_uuid: BaseAsyncQueryStorage):
+    # Given: A stred element with UUID filed
+    d = Duuid(name="foo", value="beer")
+    await storage_uuid.create(d)
+    # When: Filrter by UUID
+    ret = [item async for item in storage_uuid.where("uuid", "==", d.uuid).get_all()]
+    # Then: The element is returned
+    assert len(ret) == 1

--- a/tests/all_storage/test_all_async_storage.py
+++ b/tests/all_storage/test_all_async_storage.py
@@ -6,7 +6,6 @@ import pytest
 from pydantic import BaseModel, Field
 
 from ampf.base import BaseAsyncStorage, KeyExistsException
-from ampf.base.base_async_query_storage import BaseAsyncQueryStorage
 from ampf.base.exceptions import KeyNotExistsException
 from ampf.gcp import GcpAsyncStorage
 from ampf.in_memory import InMemoryAsyncStorage
@@ -283,36 +282,6 @@ async def test_async_where_embedding(storage: BaseAsyncStorage[D]):
     # Then: Only one is returned
     assert len(nearest) == 1
     assert nearest[0] == tc1
-
-
-@pytest.mark.asyncio
-async def test_query(storage: BaseAsyncQueryStorage):
-    # Given: Stored two elements with the same value and one with other
-    await storage.save(D(name="foo", value="beer"))
-    await storage.save(D(name="bar", value="beer"))
-    await storage.save(D(name="baz", value="wine"))
-    # When: Get all items with "beer"
-    ret = [item async for item in storage.where("value", "==", "beer").get_all()]
-    # Then: Two items are returned
-    assert len(ret) == 2
-    assert ret[0].name in ["foo", "bar"]
-    assert ret[1].name in ["foo", "bar"]
-    # When: Get all items different than "beer"
-    ret = [item async for item in storage.where("value", "!=", "beer").get_all()]
-    # Then: One item is returned
-    assert len(ret) == 1
-    assert ret[0].name == "baz"
-
-
-@pytest.mark.asyncio
-async def test_query_uuid(storage_uuid: BaseAsyncQueryStorage):
-    # Given: A stred element with UUID filed
-    d = Duuid(name="foo", value="beer")
-    await storage_uuid.create(d)
-    # When: Filrter by UUID
-    ret = [item async for item in storage_uuid.where("uuid", "==", d.uuid).get_all()]
-    # Then: The element is returned
-    assert len(ret) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/all_storage/test_all_query_storage.py
+++ b/tests/all_storage/test_all_query_storage.py
@@ -1,0 +1,89 @@
+from typing import List, Optional
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic import BaseModel, Field
+
+from ampf.base.base_query_storage import BaseQueryStorage
+from ampf.gcp import GcpStorage
+from ampf.in_memory import InMemoryStorage
+from ampf.local import JsonMultiFilesStorage, JsonOneFileStorage
+
+
+class D(BaseModel):
+    name: str
+    value: str
+    embedding: Optional[List[float]] = None
+
+
+class Duuid(BaseModel):
+    uuid: UUID = Field(default_factory=uuid4)
+    name: str
+    value: str
+
+
+@pytest.fixture(params=[InMemoryStorage, JsonOneFileStorage, JsonMultiFilesStorage, GcpStorage])
+def storage(gcp_factory, request, tmp_path):
+    if request.param in [JsonOneFileStorage, JsonMultiFilesStorage]:
+        storage = request.param("test", D, root_path=tmp_path)
+    elif request.param == GcpStorage:
+        storage = gcp_factory.create_storage("test", D)
+    else:
+        storage = request.param("test", D)
+    yield storage
+    storage.drop()
+
+
+@pytest.fixture(params=[InMemoryStorage, JsonOneFileStorage, JsonMultiFilesStorage, GcpStorage])
+def storage_key(gcp_factory, request, tmp_path):
+    if request.param in [JsonOneFileStorage, JsonMultiFilesStorage]:
+        storage = request.param("test", D, key=lambda d: d.value, root_path=tmp_path)
+    elif request.param == GcpStorage:
+        storage = gcp_factory.create_storage("test", D, key=lambda d: d.value)
+    else:
+        storage = request.param("test", D, key=lambda d: d.value)
+    yield storage
+    storage.drop()
+
+
+@pytest.fixture(params=[InMemoryStorage, JsonOneFileStorage, JsonMultiFilesStorage, GcpStorage])
+def storage_uuid(gcp_factory, request, tmp_path):
+    if request.param in [JsonOneFileStorage, JsonMultiFilesStorage]:
+        storage = request.param("test", Duuid, root_path=tmp_path)
+    elif request.param == GcpStorage:
+        storage = gcp_factory.create_storage("test", Duuid)
+    else:
+        storage = request.param("test", Duuid)
+    yield storage
+    storage.drop()
+
+
+
+def test_query(storage: BaseQueryStorage):
+    # Given: Stored two elements with the same value and one with other
+    storage.save(D(name="foo", value="beer"))
+    storage.save(D(name="bar", value="beer"))
+    storage.save(D(name="baz", value="wine"))
+    # When: Get all items with "beer"
+    ret = list(storage.where("value", "==", "beer").get_all())
+    # Then: Two items are returned
+    assert len(ret) == 2
+    assert ret[0].name in ["foo", "bar"]
+    assert ret[1].name in ["foo", "bar"]
+    # When: Get all items different than "beer"
+    ret = list(storage.where("value", "!=", "beer").get_all())
+    # Then: One item is returned
+    assert len(ret) == 1
+    assert ret[0].name == "baz"
+
+
+def test_query_uuid(storage_uuid: BaseQueryStorage):
+    # Given: A stred element with UUID filed
+    d = Duuid(name="foo", value="beer")
+    storage_uuid.create(d)
+    # When: Filrter by UUID
+    ret = [item for item in storage_uuid.where("uuid", "==", d.uuid).get_all()]
+    # Then: The element is returned
+    assert len(ret) == 1
+
+

--- a/tests/all_storage/test_all_query_storage.py
+++ b/tests/all_storage/test_all_query_storage.py
@@ -14,6 +14,7 @@ class D(BaseModel):
     name: str
     value: str
     embedding: Optional[List[float]] = None
+    tags: Optional[List[str]] = None
 
 
 class Duuid(BaseModel):
@@ -58,7 +59,6 @@ def storage_uuid(gcp_factory, request, tmp_path):
     storage.drop()
 
 
-
 def test_query(storage: BaseQueryStorage):
     # Given: Stored two elements with the same value and one with other
     storage.save(D(name="foo", value="beer"))
@@ -81,9 +81,20 @@ def test_query_uuid(storage_uuid: BaseQueryStorage):
     # Given: A stred element with UUID filed
     d = Duuid(name="foo", value="beer")
     storage_uuid.create(d)
-    # When: Filrter by UUID
+    # When: Filter by UUID
     ret = [item for item in storage_uuid.where("uuid", "==", d.uuid).get_all()]
     # Then: The element is returned
     assert len(ret) == 1
 
 
+def test_query_array_contains_any(storage: BaseQueryStorage):
+    storage.save(D(name="d1", value="v1", tags=["tag1", "tag2"]))
+    storage.save(D(name="d2", value="v2", tags=["tag2", "tag3"]))
+    storage.save(D(name="d3", value="v3", tags=["tag4"]))
+
+    result = list(storage.where("tags", "array_contains_any", ["tag1", "tag4"]).get_all())
+    assert len(result) == 2
+    assert {r.name for r in result} == {"d1", "d3"}
+
+    result = list(storage.where("tags", "array_contains_any", ["tag5"]).get_all())
+    assert len(result) == 0

--- a/tests/all_storage/test_all_storage.py
+++ b/tests/all_storage/test_all_storage.py
@@ -128,7 +128,7 @@ def test_patch_key_value(storage: BaseStorage):
     # Then: An old key doesn't exist
     with pytest.raises(KeyNotExistsException):
         storage.get("foo")
-    # And: A new key exists   
+    # And: A new key exists
     assert D(name="bar", value="beer") == storage.get("bar")
 
 
@@ -259,34 +259,6 @@ def test_where_embedding(storage: BaseStorage[D]):
     assert nearest[0] == tc1
 
 
-def test_query(storage: BaseQueryStorage):
-    # Given: Stored two elements with the same value and one with other
-    storage.save(D(name="foo", value="beer"))
-    storage.save(D(name="bar", value="beer"))
-    storage.save(D(name="baz", value="wine"))
-    # When: Get all items with "beer"
-    ret = list(storage.where("value", "==", "beer").get_all())
-    # Then: Two items are returned
-    assert len(ret) == 2
-    assert ret[0].name in ["foo", "bar"]
-    assert ret[1].name in ["foo", "bar"]
-    # When: Get all items different than "beer"
-    ret = list(storage.where("value", "!=", "beer").get_all())
-    # Then: One item is returned
-    assert len(ret) == 1
-    assert ret[0].name == "baz"
-
-
-def test_query_uuid(storage_uuid: BaseQueryStorage):
-    # Given: A stred element with UUID filed
-    d = Duuid(name="foo", value="beer")
-    storage_uuid.create(d)
-    # When: Filrter by UUID
-    ret = [item for item in storage_uuid.where("uuid", "==", d.uuid).get_all()]
-    # Then: The element is returned
-    assert len(ret) == 1
-
-
 def test_put_not_exists(storage: BaseStorage):
     # When: I put a new object
     storage.put("foo", D(name="foo", value="wine"))
@@ -302,6 +274,7 @@ def test_put_exists(storage: BaseStorage):
     # Then: It is changed
     assert storage.get("foo").value == "wine"
 
+
 def test_put_new_key(storage: BaseStorage):
     # Given: A new saved element
     storage.create(D(name="foo", value="beer"))
@@ -312,4 +285,3 @@ def test_put_new_key(storage: BaseStorage):
         storage.get("foo").value
     # And: New object exists
     assert storage.get("foo2").value == "beer"
-

--- a/tests/all_storage/test_all_storage.py
+++ b/tests/all_storage/test_all_storage.py
@@ -5,7 +5,6 @@ import pytest
 from pydantic import BaseModel, Field
 
 from ampf.base import BaseStorage, KeyExistsException, KeyNotExistsException
-from ampf.base.base_query_storage import BaseQueryStorage
 from ampf.gcp import GcpStorage
 from ampf.in_memory import InMemoryStorage
 from ampf.local import JsonMultiFilesStorage, JsonOneFileStorage


### PR DESCRIPTION
This pull request introduces the `array_contains_any` operator to `BaseQuery` and `BaseAsyncQuery`, allowing filtering of data models where an array field contains any of the specified values.

Additionally, query-related tests have been refactored and moved into dedicated test files (`test_all_async_query_storage.py` and `test_all_query_storage.py`) for improved organization and maintainability.